### PR TITLE
Deprecate curly braces array access

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ rfc2epub - create an epub ebook from an IETF RFC
 
 -e    show usage examples  
 -h    print this message  
--f    replace the vendors font with M+ M1 (a very narrow monospaced font by the M+ FONTS PROJECT) 
+-f    replace the vendors font with M+ M1 (a very narrow monospaced font by the M+ FONTS PROJECT)  
 -d    do not package the book to epub but create the file and directory structure with all its contents  
 -t    create a table of contents  
 

--- a/rfc2epub
+++ b/rfc2epub
@@ -93,7 +93,7 @@ EOU;
     array_shift($argv);
     while (1) {
         $s = reset($argv);
-        if ($s{0} == "-" && (!isset($s{1}) || (isset($s{1}) && $s{1} != "-"))) {
+        if ($s[0] == "-" && (!isset($s[1]) || (isset($s[1]) && $s[1] != "-"))) {
             $flagsv[] = array_shift($argv);
         } else {
             break;


### PR DESCRIPTION
After PHP 7.4, curly brace syntax for accessing array elements and string offsets was deprecated.
https://wiki.php.net/rfc/deprecate_curly_braces_array_access

Fixed it and tested with PHP 7.4.6 on macOS 10.15.4, installed from Homebrew.

```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.4
BuildVersion:	19E287
$ php -v
PHP 7.4.6 (cli) (built: May 14 2020 10:38:36) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.6, Copyright (c), by Zend Technologies
```