### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.2-alpine
+
+RUN apk add --no-cache \
+      libzip-dev \
+      zip \
+      tidyhtml-dev \
+    && docker-php-ext-install zip tidy
+COPY . .
+ENTRYPOINT ["./rfc2epub"]

--- a/README.md
+++ b/README.md
@@ -59,17 +59,30 @@ rfc2epub - create an epub ebook from an IETF RFC
 
 ### Install on Linux 
 
- ```bash
-git clone https://github.com/aichigm/rfc2epub
+```bash
+git clone https://github.com/aichingm/rfc2epub
 mv rfc2epub/rfc2epub.php rfc2epub/rfc2epub
 chmod +x rfc2epub/rfc2epub
 echo "PATH=$(pwd)/rfc2epub:\$PATH" >> ~/.bashrc
 
 # run it everywhere with
 rfc2epub 
- ```
+```
 
 
+## Run in Docker Image
+
+### Build image
+
+1. Clone the repository
+2. Run the build, e.g., `docker build . --tag rfc2epub`
+
+### Execute script
+
+```bash
+mkdir output
+docker run -it -v ./output:/output --rm rfc2epub 6749 /output/6749.epub
+```
 
 ### Special Thanks
 

--- a/rfc2epub
+++ b/rfc2epub
@@ -1,4 +1,4 @@
-#!/bin/env php
+#!/usr/bin/env php
 <?php
 
 function usageExit($exitCode) {


### PR DESCRIPTION
Sometimes we don't want to install additional dependencies if we want to run the script one time. This MR adds Dockerfile that we can use to build the image, run the script and get the output without installing additional software.